### PR TITLE
refactor: Rework sidebar toggle logic using event delegation

### DIFF
--- a/assets/default_app.js
+++ b/assets/default_app.js
@@ -169,73 +169,65 @@ window.initThemeToggle = function () {
   });
 };
 
-// Left sidebar logic
-window.setupLeftSidebarInteraction = function () {
-  const toggleBtns = document.querySelectorAll(".sidebar-toggle.left-toggle");
-  const sidebar = document.getElementById("left-sidebar");
-  if (!toggleBtns.length || !sidebar) return;
+// Sidebar toggle via event delegation (survives htmx swaps without re-binding)
+window.setupSidebarDelegation = function () {
+  if (window._sidebarDelegationBound) return;
+  window._sidebarDelegationBound = true;
 
-  toggleBtns.forEach((btn) => {
-    const newBtn = btn.cloneNode(true);
-    btn.parentNode.replaceChild(newBtn, btn);
-    newBtn.addEventListener("click", () => {
-      sidebar.classList.toggle("collapsed");
-      if (window.innerWidth >= 1280) {
-        localStorage.setItem(
-          "left-sidebar",
-          sidebar.classList.contains("collapsed"),
-        );
-      }
-    });
-  });
-};
-
-// Right sidebar logic
-window.setupRightSidebarInteraction = function () {
-  const toggleBtns = document.querySelectorAll(".sidebar-toggle.right-toggle");
-  const sidebar = document.getElementById("right-sidebar");
-  if (!toggleBtns.length || !sidebar) return;
-
-  toggleBtns.forEach((btn) => {
-    const newBtn = btn.cloneNode(true);
-    btn.parentNode.replaceChild(newBtn, btn);
-    newBtn.addEventListener("click", () => {
-      sidebar.classList.toggle("collapsed");
-      if (window.innerWidth >= 1280) {
-        localStorage.setItem(
-          "right-sidebar",
-          sidebar.classList.contains("collapsed"),
-        );
-      }
-    });
-  });
-};
-
-// Sidebars autoclose on mobile logic
-window.setupMobileAutoClose = function () {
   document.body.addEventListener("click", (e) => {
-    if (window.innerWidth > 1280) return;
+    const leftBtn = e.target.closest(".sidebar-toggle.left-toggle");
+    const rightBtn = e.target.closest(".sidebar-toggle.right-toggle");
 
+    if (leftBtn) {
+      e.stopPropagation();
+      window.toggleSidebar("left-sidebar", "right-sidebar");
+      return;
+    }
+    if (rightBtn) {
+      e.stopPropagation();
+      window.toggleSidebar("right-sidebar", "left-sidebar");
+      return;
+    }
+
+    // Mobile auto-close: close open sidebars when clicking a link or graph node
+    if (window.innerWidth >= 1280) return;
     const link = e.target.closest("a");
     const isGraphNode =
       ["circle", "text"].includes(e.target.tagName.toLowerCase()) &&
       (e.target.closest("#global-graph-container") ||
         e.target.closest("#local-graph-container"));
-
     if (!link && !isGraphNode) return;
 
-    // Close sidebars on mobile by removing the collapsed class
-    // (on mobile, "collapsed" class = visible, default = hidden)
-    ["left-sidebar", "right-sidebar"].forEach((id) => {
-      const el = document.getElementById(id);
-      if (el && el.classList.contains("collapsed")) {
-        el.classList.remove("collapsed");
-        localStorage.removeItem(
-          id === "left-sidebar" ? "left-sidebar" : "right-sidebar",
-        );
-      }
-    });
+    window.closeSidebar("left-sidebar");
+    window.closeSidebar("right-sidebar");
   });
+};
+
+window.toggleSidebar = function (id, otherId) {
+  const sidebar = document.getElementById(id);
+  if (!sidebar) return;
+
+  // On mobile, close the other sidebar first
+  if (window.innerWidth < 1280) {
+    window.closeSidebar(otherId);
+  }
+
+  sidebar.classList.toggle("collapsed");
+
+  if (window.innerWidth >= 1280) {
+    localStorage.setItem(id, sidebar.classList.contains("collapsed"));
+  }
+};
+
+window.closeSidebar = function (id) {
+  const sidebar = document.getElementById(id);
+  if (!sidebar) return;
+  // On mobile, "collapsed" = visible, so removing it hides the sidebar.
+  // On desktop, "collapsed" = hidden, so removing it shows the sidebar.
+  // We only auto-close on mobile, where removing "collapsed" is correct.
+  if (sidebar.classList.contains("collapsed")) {
+    sidebar.classList.remove("collapsed");
+  }
 };
 
 // Navbar search
@@ -351,8 +343,7 @@ window.addCopyButtons = function () {
 window.initAll = function () {
   window.initThemeToggle();
   window.initNavbarSearch();
-  window.setupRightSidebarInteraction();
-  window.setupLeftSidebarInteraction();
+  window.setupSidebarDelegation();
   window.highlightSidebarLink();
   window.addCopyButtons();
 
@@ -361,7 +352,6 @@ window.initAll = function () {
 
 document.addEventListener("DOMContentLoaded", () => {
   window.initAll();
-  window.setupMobileAutoClose();
 });
 
 document.addEventListener("htmx:afterSwap", () => {

--- a/assets/simple_app.js
+++ b/assets/simple_app.js
@@ -13,85 +13,65 @@ window.loadScript = function (src, id) {
   });
 };
 
+// Panel definitions: each maps a button ID to its wrapper and icon IDs.
+window._panels = [
+  { btn: "menu-button", wrapper: "menu-wrapper", icon: "menu-icon" },
+  {
+    btn: "local-graph-button",
+    wrapper: "local-graph-wrapper",
+    icon: "local-graph-icon",
+  },
+  { btn: "toc-button", wrapper: "toc-wrapper", icon: "toc-icon" },
+];
+
+// Close a single panel by looking up its current DOM elements.
+window._closePanel = function (panel) {
+  const wrapper = document.getElementById(panel.wrapper);
+  const icon = document.getElementById(panel.icon);
+  if (wrapper) wrapper.classList.add("hidden");
+  if (icon) {
+    icon.classList.remove("text-accent");
+    icon.classList.add("text-foreground");
+  }
+};
+
+// Toggle a panel: close all others, then toggle the target.
+window._togglePanel = function (panel) {
+  window._panels.forEach((p) => {
+    if (p.wrapper !== panel.wrapper) window._closePanel(p);
+  });
+  const wrapper = document.getElementById(panel.wrapper);
+  const icon = document.getElementById(panel.icon);
+  if (!wrapper) return;
+  const opening = wrapper.classList.contains("hidden");
+  wrapper.classList.toggle("hidden");
+  if (icon) {
+    icon.classList.toggle("text-accent", opening);
+    icon.classList.toggle("text-foreground", !opening);
+  }
+};
+
+// Named toggle functions referenced by inline scripts (e.g. TOC link clicks).
+window.toggleMenu = () =>
+  window._togglePanel(window._panels[0]);
+window.toggleLocalGraph = () =>
+  window._togglePanel(window._panels[1]);
+window.toggleTOC = () =>
+  window._togglePanel(window._panels[2]);
+
+// Event delegation: one listener that survives htmx swaps.
 window.initToggles = function () {
-  const menuBtn = document.getElementById("menu-button");
-  const menuIcon = document.getElementById("menu-icon");
-  const menu = document.getElementById("menu-wrapper");
+  if (window._togglesDelegationBound) return;
+  window._togglesDelegationBound = true;
 
-  window.toggleMenu = () => {
-    window.closeAllExcept("menu");
-    if (menu.classList.contains("hidden")) {
-      menu.classList.remove("hidden");
-      menuIcon.classList.add("text-accent");
-      menuIcon.classList.remove("text-foreground");
-    } else {
-      menu.classList.add("hidden");
-      menuIcon.classList.remove("text-accent");
-      menuIcon.classList.add("text-foreground");
+  document.body.addEventListener("click", (e) => {
+    for (const panel of window._panels) {
+      if (e.target.closest("#" + panel.btn)) {
+        window._togglePanel(panel);
+        return;
+      }
     }
-  };
-
-  const localGraphBtn = document.getElementById("local-graph-button");
-  const localGraphWrapper = document.getElementById("local-graph-wrapper");
-  const localGraphIcon = document.getElementById("local-graph-icon");
-  window.toggleLocalGraph = () => {
-    window.closeAllExcept("local-graph");
-    if (localGraphWrapper.classList.contains("hidden")) {
-      localGraphWrapper.classList.remove("hidden");
-      localGraphIcon.classList.add("text-accent");
-      localGraphIcon.classList.remove("text-foreground");
-    } else {
-      localGraphWrapper.classList.add("hidden");
-      localGraphIcon.classList.remove("text-accent");
-      localGraphIcon.classList.add("text-foreground");
-    }
-  };
-
-  const tocBtn = document.getElementById("toc-button");
-  const tocWrapper = document.getElementById("toc-wrapper");
-  const tocIcon = document.getElementById("toc-icon");
-  window.toggleTOC = () => {
-    window.closeAllExcept("toc");
-    if (tocWrapper.classList.contains("hidden")) {
-      tocWrapper.classList.remove("hidden");
-      tocIcon.classList.add("text-accent");
-      tocIcon.classList.remove("text-foreground");
-    } else {
-      tocWrapper.classList.add("hidden");
-      tocIcon.classList.remove("text-accent");
-      tocIcon.classList.add("text-foreground");
-    }
-  };
-
-  window.closeAllExcept = (item) => {
-    if (item !== "menu" && menu && menuIcon) {
-      menu.classList.add("hidden");
-      menuIcon.classList.remove("text-accent");
-      menuIcon.classList.add("text-foreground");
-    }
-
-    if (item !== "local-graph" && localGraphWrapper && localGraphIcon) {
-      localGraphWrapper.classList.add("hidden");
-      localGraphIcon.classList.remove("text-accent");
-      localGraphIcon.classList.add("text-foreground");
-    }
-
-    if (item !== "toc" && tocWrapper && tocIcon) {
-      tocWrapper.classList.add("hidden");
-      tocIcon.classList.remove("text-accent");
-      tocIcon.classList.add("text-foreground");
-    }
-  };
-
-  if (localGraphBtn) {
-    localGraphBtn.addEventListener("click", window.toggleLocalGraph);
-  }
-  if (menuBtn) {
-    menuBtn.addEventListener("click", window.toggleMenu);
-  }
-  if (tocBtn) {
-    tocBtn.addEventListener("click", window.toggleTOC);
-  }
+  });
 };
 
 // Lazyload MathJax
@@ -287,12 +267,12 @@ window.initAll = function () {
 };
 
 document.addEventListener("DOMContentLoaded", () => {
-  localStorage.setItem("menu", "close");
   window.initAll();
 });
 
 document.addEventListener("htmx:afterSwap", () => {
-  localStorage.setItem("menu", "close");
+  // Close all panels on navigation
+  window._panels.forEach((p) => window._closePanel(p));
   window.initAll();
 });
 


### PR DESCRIPTION
The previous sidebar open/close implementation was finicky because each toggle button had its event listeners re-bound on every htmx swap (via cloneNode). This caused inconsistent behavior, especially on mobile where auto-close logic lived in a separate handler.

Replace the per-button binding approach with a single event delegation listener on document.body that survives htmx swaps without re-binding. Extract shared toggleSidebar() and closeSidebar() helpers to consolidate open/close/localStorage logic. On mobile, opening one sidebar now closes the other.

In simple_app.js, deduplicate the three nearly-identical panel toggle functions (menu, local-graph, toc) into a data-driven _panels array with a single delegated click handler, eliminating repeated boilerplate.