### PR TITLE
fix: Prevent panic on nil frontmatter values in Head template

### DIFF
--- a/internal/templates/helpers.go
+++ b/internal/templates/helpers.go
@@ -12,6 +12,19 @@ func FormatDate(t time.Time) string {
 	return t.Format("Jan 02, 2006")
 }
 
+// toStr safely converts an interface value to a string.
+// Returns "" for nil values instead of panicking.
+func toStr(v any) string {
+	if v == nil {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Sprintf("%v", v)
+	}
+	return s
+}
+
 // buildThemeCSS builds the inline <style> block with CSS custom properties
 // for light/dark themes and @font-face declarations.
 func buildThemeCSS(theme *ThemeData) string {
@@ -27,8 +40,13 @@ func buildThemeCSS(theme *ThemeData) string {
 	b.WriteString("/* Variable definitions */\n:root {\n")
 	b.WriteString("/* --- LIGHT THEME (Default) --- */\n")
 	writeColorVars(&b, theme.Light)
-	b.WriteString(fmt.Sprintf("--sidebar-width: 280px;\n"))
-	b.WriteString(fmt.Sprintf("--font-main: %s, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, Helvetica, Arial, sans-serif;\n", theme.FontFamily))
+	b.WriteString("--sidebar-width: 280px;\n")
+	b.WriteString(
+		fmt.Sprintf(
+			"--font-main: %s, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, Helvetica, Arial, sans-serif;\n",
+			theme.FontFamily,
+		),
+	)
 	b.WriteString("}\n\n")
 
 	// Dark theme (data attribute)

--- a/internal/templates/helpers_test.go
+++ b/internal/templates/helpers_test.go
@@ -1,0 +1,84 @@
+// @feature:layouts Tests for template helper functions.
+package templates
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/otaleghani/kiln/internal/obsidian"
+)
+
+func TestToStr(t *testing.T) {
+	tests := []struct {
+		name string
+		val  any
+		want string
+	}{
+		{"nil value", nil, ""},
+		{"string value", "hello", "hello"},
+		{"empty string", "", ""},
+		{"int value", 42, "42"},
+		{"bool value", true, "true"},
+		{"float value", 3.14, "3.14"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toStr(tt.val)
+			if got != tt.want {
+				t.Errorf("toStr(%v) = %q, want %q", tt.val, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHead_NilFrontmatterValues(t *testing.T) {
+	tests := []struct {
+		name        string
+		frontmatter map[string]any
+	}{
+		{
+			name:        "nil title and description",
+			frontmatter: map[string]any{"title": nil, "description": nil},
+		},
+		{
+			name:        "nil frontmatter map",
+			frontmatter: nil,
+		},
+		{
+			name:        "empty frontmatter",
+			frontmatter: map[string]any{},
+		},
+		{
+			name:        "valid title, nil description",
+			frontmatter: map[string]any{"title": "My Page", "description": nil},
+		},
+		{
+			name:        "nil title, valid description",
+			frontmatter: map[string]any{"title": nil, "description": "A description"},
+		},
+		{
+			name:        "non-string title",
+			frontmatter: map[string]any{"title": 123},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := &PageData{
+				File:        &obsidian.File{Name: "test-note"},
+				Frontmatter: tt.frontmatter,
+				Site: &SiteData{
+					SiteName: "Test Site",
+				},
+			}
+
+			var buf bytes.Buffer
+			err := Head(data).Render(context.Background(), &buf)
+			if err != nil {
+				t.Fatalf("Head() returned error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/templates/shared.templ
+++ b/internal/templates/shared.templ
@@ -194,15 +194,15 @@ templ Canonical(data *PageData) {
 templ Head(data *PageData) {
 	if !data.IsFolder && !data.IsTag && data.File != nil {
 		<title>
-			if title, ok := data.Frontmatter["title"]; ok {
-				{ title.(string) }
+			if title, ok := data.Frontmatter["title"]; ok && toStr(title) != "" {
+				{ toStr(title) }
 			} else {
 				{ data.File.Name }
 			}
 			{ " • " + data.Site.SiteName }
 		</title>
-		if desc, ok := data.Frontmatter["description"]; ok {
-			<meta name="description" content={ desc.(string) }/>
+		if desc, ok := data.Frontmatter["description"]; ok && toStr(desc) != "" {
+			<meta name="description" content={ toStr(desc) }/>
 		} else if data.File != nil {
 			<meta name="description" content={ "Notes on " + data.File.Name }/>
 		}

--- a/internal/templates/shared_templ.go
+++ b/internal/templates/shared_templ.go
@@ -552,11 +552,11 @@ func Head(data *PageData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if title, ok := data.Frontmatter["title"]; ok {
+			if title, ok := data.Frontmatter["title"]; ok && toStr(title) != "" {
 				var templ_7745c5c3_Var25 string
-				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(title.(string))
+				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(toStr(title))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/shared.templ`, Line: 198, Col: 20}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/shared.templ`, Line: 198, Col: 18}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 				if templ_7745c5c3_Err != nil {
@@ -594,15 +594,15 @@ func Head(data *PageData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if desc, ok := data.Frontmatter["description"]; ok {
+			if desc, ok := data.Frontmatter["description"]; ok && toStr(desc) != "" {
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "<meta name=\"description\" content=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var28 string
-				templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(desc.(string))
+				templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(toStr(desc))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/shared.templ`, Line: 205, Col: 51}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/templates/shared.templ`, Line: 205, Col: 49}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 				if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
Replace unsafe type assertions (e.g. title.(string)) with a safe toStr() helper that handles nil and non-string values gracefully. This fixes #41 where pages with nil frontmatter values for "title" or "description" caused a panic during markdown rendering.

Also adds unit tests for toStr() and Head() with various nil/missing frontmatter scenarios.