### PR TITLE
Adjust nginx example to also try $uri.html

### DIFF
--- a/docs/Deployment/Web Servers.md
+++ b/docs/Deployment/Web Servers.md
@@ -28,7 +28,7 @@ server {
 
     location / {
         # Try to serve the file directly, then as a directory (index.html), then 404
-        try_files $uri $uri/ =404;
+        try_files $uri $uri/ $uri.html =404;
     }
 
     # Optional: Cache static assets for better performance


### PR DESCRIPTION
Kiln renders pages as pagename.html so nginx needs to try that extension for the website to resolve links correctly.